### PR TITLE
Theme oopsies

### DIFF
--- a/components/02-compounds/lits-search/_google-json-api-search.twig
+++ b/components/02-compounds/lits-search/_google-json-api-search.twig
@@ -34,7 +34,7 @@
         {%- if items -%}
           {%- for item in items -%}
             {%- if item.value['#theme'] == "google_json_api_result" -%}{# If not a real result #}
-              {%- item.attributes.addClass('search-result--no-columns') %}
+              {%- set foo = item.attributes.addClass('search-result--no-columns') -%}
               <article{{ item.attributes }}>{{ item.value }}</article>
               {%- if loop.last -%}
                 <div class='result-summary {{ result_summary_class }}'>{{ result_summary }}</div> {# top of page message #}


### PR DESCRIPTION
## Description

Twig is being weird about removing the `set foo = ` from `components/02-compounds/lits-search/_google-json-api-search.twig` and we don't have time to chase why, so whatever we can let it have it back.

## Future Work

Always but hopefully not for this right this second.

## Testing

Describe how the tester could verify that this branch works. Did you add any automated tests?

### To be completed by the person testing

- [ ] Visual confirmation of new functionality
- [ ] Tests pass
- [ ] Related documentation has been updated
