### PR TITLE
Updates to news item handling for better UX in RSS

### DIFF
--- a/lits_theme.theme
+++ b/lits_theme.theme
@@ -10,6 +10,7 @@ use Drupal\Core\Url;
 use Drupal\file\Entity\File;
 use Drupal\media\Entity\Media;
 use Drupal\taxonomy\Entity\Term;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * @file
@@ -490,23 +491,43 @@ function lits_theme_preprocess_node__article__search_result(&$variables) {
 * Implements hook_preprocess_node().
 *
 * If field_meal empty, then show the contents of field_bite instead
+* If field_url is not empty, the URL is external, and the current user does not
+*    have permission to edit it – redirect to field_url instead of showing the 
+*    node.
 */
 function lits_theme_preprocess_node__news_item__full(&$variables) {
-
   $node = $variables['node'];
   $meal = $node->get('field_meal')->getValue();
 
+  // Find URL for the node
+  $fieldUrlArray = $node->get('field_url')->getValue();
+  if (is_array($fieldUrlArray) && !empty($fieldUrlArray) && is_array($fieldUrlArray[0]) && array_key_exists('uri', $fieldUrlArray[0]) && !empty($fieldUrlArray[0]['uri'])) {
+    $fieldUrlUri = $fieldUrlArray[0]['uri'];
+  }
+
+  // If field_meal empty, then show the contents of field_bite instead
   if (is_array($meal) && empty($meal)) {
     $bite = $node->get('field_bite')->getValue();
     $uri = 'entity:node/' . $node->id();
-    $val = $node->get('field_url')->getValue();
-    if (is_array($val) && !empty($val) && is_array($val[0]) && array_key_exists('uri', $val[0]) && !empty($val[0]['uri'])) {
-      $uri = $val[0]['uri'];
+    
+    if (!empty($fieldUrlUri)) {
+      $uri = $fieldUrlUri;
     }
 
     $variables['content']['no-meal'] = [
       '#markup' =>  $bite[0]['value'] . $uri ,
     ];
+  }
+
+  // If field_url is not empty, the URL is external, and the current user does not
+  //    have permission to edit it – redirect to field_url instead of showing the 
+  //    node.
+  if (!empty($fieldUrlUri)) {
+    $fieldUrlUrl = Url::fromUri($fieldUrlUri);
+    if ($fieldUrlUrl->isExternal() && ! \Drupal::currentUser()->hasPermission('edit news item')) {
+      $redirect = new RedirectResponse($fieldUrlUrl->toString());
+      $redirect->send();
+    }
   }
 }
 

--- a/lits_theme.theme
+++ b/lits_theme.theme
@@ -491,9 +491,8 @@ function lits_theme_preprocess_node__article__search_result(&$variables) {
 * Implements hook_preprocess_node().
 *
 * If field_meal empty, then show the contents of field_bite instead
-* If field_url is not empty, the URL is external, and the current user does not
-*    have permission to edit it – redirect to field_url instead of showing the 
-*    node.
+* If field_url is not empty and the current user does not have permission to
+*    edit it, redirect to field_url instead of showing the node.
 */
 function lits_theme_preprocess_node__news_item__full(&$variables) {
   $node = $variables['node'];
@@ -519,12 +518,11 @@ function lits_theme_preprocess_node__news_item__full(&$variables) {
     ];
   }
 
-  // If field_url is not empty, the URL is external, and the current user does not
-  //    have permission to edit it – redirect to field_url instead of showing the 
-  //    node.
+  // If field_url is not empty and the current user does not have permission to
+  //    edit it, redirect to field_url instead of showing the node.
   if (!empty($fieldUrlUri)) {
     $fieldUrlUrl = Url::fromUri($fieldUrlUri);
-    if ($fieldUrlUrl->isExternal() && ! \Drupal::currentUser()->hasPermission('edit news item')) {
+    if (! \Drupal::currentUser()->hasPermission('edit news item')) {
       $redirect = new RedirectResponse($fieldUrlUrl->toString());
       $redirect->send();
     }


### PR DESCRIPTION
## Description

Zoë noted that news items that are set up as redirects aren't being properly redirected when people click on them in the RSS feed on the AskLITS portal homepage.

We unsuccessfully looked at a few ways to accomplish this, including:
- Modifying the RSS feed view to return the "correct" URL
- Hooking into the view (rows, etc) to change the URL to the "correct" one
- Modifying the view template to use the "correct" URL

Long story short, the RSS views handling is _not_ amenable to changing something as "fixed" as the URL for the item.

That left a not-so-ideal solution.

For news items, redirect to the field_url if it's a) specified and b) the current user does not have access to edit news items. This is to make it so that news items behave correctly when users click on a news item with an override URL in the RSS feed on the AskLITS portal while retaining the ability for users with the correct permissions to edit those news items.

## Future Work

Hopefully not around this specific UX concern, but we'll see.

## Testing

As an administrator/a user with edit permissions:
- The URL for the "Change the subject" news item on /news should go to https://events.mtholyoke.edu/event/change_the_subject_a_documentary_about_libraries_labels_and_activism#.XYUiwShKhtQ directly (no change from prod)
- The news item page for that item should be visible at /news/2019-10-04/change-subject
- The news item page for /news/2019-09-06/academic-home-use-software-licenses should be visible
- The news item page for a regular ole news item like /news/2023-11-21/learning-management-system-product-demos should also be visible (no change from prod)

As an anonymous user (incognito mode or whatever):
- The URL for the "Change the subject" news item on /news should go to https://events.mtholyoke.edu/event/change_the_subject_a_documentary_about_libraries_labels_and_activism#.XYUiwShKhtQ directly (no change from prod)
- The news item page for that item (/news/2019-10-04/change-subject) should redirect to https://events.mtholyoke.edu/event/change_the_subject_a_documentary_about_libraries_labels_and_activism#.XYUiwShKhtQ without user input (**new** change from prod)
- The news item page for /news/2019-09-06/academic-home-use-software-licenses should redirect to /tech-support/tools-doing-work/personal-tech-purchases (**new** change from prod)
- The news item page for a regular ole news item like /news/2023-11-21/learning-management-system-product-demos should also be visible (no change from prod)

### To be completed by the person testing

- [ ] Visual confirmation of new functionality
- [ ] Tests pass
- [ ] Related documentation has been updated
