### PR TITLE
System status: tweak to comment display on table

### DIFF
--- a/lits_theme.theme
+++ b/lits_theme.theme
@@ -627,10 +627,11 @@ function lits_theme_sort_system_status_updates(&$variables, $returnAllUpdates) {
   if (!$returnAllUpdates) {
     if (count($variables['content']['field_comments'][0]['comments']) > 0) {
       $mostRecentUpdate = $variables['content']['field_comments'][0]['comments'][0];
-      // Only add comments with modification dates that are reasonably current
+      // Only add comments with modification dates that are reasonably current,
+      //  or if the status is unavailable, degraded, or planned maintenance  (status_id less than 40).
       $cutoff = strtotime('-7 days');
       $modified = $mostRecentUpdate['#comment']->getChangedTime();
-      if($cutoff < $modified) {
+      if($cutoff < $modified || $variables['content']['#status_id'] < "40") {
         foreach (array_keys($variables['content']['field_comments'][0]['comments']) as $key) {
           if (is_numeric($key) && $key != 0) {
             $variables['content']['field_comments'][0]['comments'][$key] = NULL;


### PR DESCRIPTION
## Description

For unavailable, degraded, and planned maintenance statuses – keep the latest comment on the system status table indefnitely. For normal statuses – keep the latest comment for 7 days.

This addresses times when a sad status goes on for a long time, but doesn't require regular updates.

Uses https://github.com/mtholyoke/lits/pull/501 for environment testing.

## Future Work

If additional work is required before the task is complete, list it here. If there are optional enhancements, list those here too.

## Testing

Describe how the tester could verify that this branch works. Did you add any automated tests?

### To be completed by the person testing

- [ ] Visual confirmation of new functionality
- [ ] Tests pass
- [ ] Related documentation has been updated
