### PR TITLE
Replace Emulsify Twig with Emulsify Tools

### DIFF
--- a/components/01-elements/05-forms/_button.twig
+++ b/components/01-elements/05-forms/_button.twig
@@ -20,4 +20,4 @@
 {% if element["#content"] == NULL or element["#content"] == "" %}
   {% set content = element["#value"] %}
 {% endif %}
-<button{{ attributes.addClass(classes) }} />{{ content|raw }}</button>
+<button{{ attributes.addClass(classes) }}>{{ content|raw }}</button>

--- a/components/02-compounds/homepage-elements/_field-featured-resources.twig
+++ b/components/02-compounds/homepage-elements/_field-featured-resources.twig
@@ -4,7 +4,7 @@
     <ul>
       <li class="tdx-tile">
         <a href="https://asklits.mtholyoke.edu/TDClient/50/Portal/Home/">
-          <img src="{{ jorge_image_url }}" />
+          <img src="{{ jorge_image_url }}" aria-hidden="true" />
           <span>AskLITS portal</span>
         </a>
       </li>

--- a/components/02-compounds/main-menu/main-menu.twig
+++ b/components/02-compounds/main-menu/main-menu.twig
@@ -22,7 +22,7 @@
       <li id="main-menu_hours-accounts" class="main-menu__item main-menu__item--root">
         <div><a class="hours" href="/about-lits/service-desks">LITS hours</a></div>
         <div id="main-menu_hours-accounts-divider"><span></span></div>
-        <div><a class="accounts" href="/my-library-accounts">My library accounts</a></span></div>
+        <div><a class="accounts" href="/my-library-accounts">My library accounts</a></div>
       </li>
       {% for item in items %}
         {% include "@compounds/main-menu/main-menu-item-root.twig" with {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     "license": "MIT",
     "minimum-stability": "beta",
     "require": {
-        "drupal/emulsify_twig": "^4.0"
+        "drupal/emulsify_tools": "^1.0"
     }
 }

--- a/lits_theme.info.yml
+++ b/lits_theme.info.yml
@@ -7,9 +7,9 @@ version: VERSION
 libraries:
   - lits_theme/base
   - core/normalize
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10
 dependencies:
-  - drupal:emulsify_twig
+  - drupal:emulsify_tools
 generator: 'starterkit_theme:9.5.10'
 # CKEditor stylesheet loads in wysiwyg to give content editors a better experience
 ckeditor5-stylesheets:


### PR DESCRIPTION
## Description

[Emulsify Twig](https://www.drupal.org/project/emulsify_twig) is now called [Emulsify Tools](https://www.drupal.org/project/emulsify_tools) (and has some new functionality around subtheming but right now we only care about the Twig extensions)

Also I found an error in our html: buttons on forms (such as search) were all structured like
```html
<button [attrs] />[content]</button>
```
instead of
```html
<button [attrs]>[content]</button>
```

Also also this fixes #16 by adding `aria-hidden="true"` to the Jorge image on the AskLITS featured resource tile.


## Future Work

No, this is fairly well self-contained. That said, it’s got to be a two-step deploy in the main LITS website project: the first (to be folded into [PR #514 there](https://github.com/mtholyoke/lits/pull/514)) both incorporates this update and adds Emulsify Twig to its `composer.json` but disables it as an installed module; the second will remove it from `composer.json`.

## Testing

We use the `bem()` function in a bunch of places; make sure it’s still doing its thing.

The easiest to find and the simplest usage is the `<article>` tag in `_node.twig`:
```twig
<article {{ bem("node") }}>
```
Every node which uses that template (all of them?) should have 
```html
<article  class="node">
```

It’s worth doublechecking some more complicated use cases. On my local I manually removed the `emulsify_twig` directory to be sure it was finding the module at its new location. 


### To be completed by the person testing

- [ ] Visual confirmation of new functionality
- [ ] Tests pass
- [ ] Related documentation has been updated
